### PR TITLE
refactor(web): extract shared article helpers and add tests

### DIFF
--- a/apps/web/src/components/articles/shared-article-helpers.test.ts
+++ b/apps/web/src/components/articles/shared-article-helpers.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   formatCommentDate,
+  insertCommentTree,
   normalizeDisplayName,
+  removeCommentTree,
   sortCommentThread,
   toCommentSortOption,
+  updateCommentTree,
   withThreadDefaults,
 } from "@/components/articles/shared-article-helpers";
 import type { SharedArticleComment } from "@/lib/api/articles";
@@ -57,6 +60,38 @@ describe("shared article helpers", () => {
     expect(comments.map((comment) => comment.id)).toEqual(["top", "newer", "older"]);
   });
 
+  it("sorts latest threads by recency", () => {
+    const comments = sortCommentThread(
+      [
+        makeComment({ id: "older", created_at: "2026-03-29T08:00:00.000Z" }),
+        makeComment({ id: "newer", created_at: "2026-03-30T08:00:00.000Z" }),
+      ],
+      "latest"
+    );
+
+    expect(comments.map((comment) => comment.id)).toEqual(["newer", "older"]);
+  });
+
+  it("updates, inserts, and removes nested comments", () => {
+    const child = makeComment({ id: "child", parent_comment_id: "parent" });
+    const parent = makeComment({ id: "parent", replies: [child] });
+
+    const updated = updateCommentTree([parent], "child", (comment) => ({
+      ...comment,
+      content: "updated",
+    }));
+    expect(updated[0].replies[0].content).toBe("updated");
+
+    const inserted = insertCommentTree(
+      updated,
+      makeComment({ id: "child-2", parent_comment_id: "parent" })
+    );
+    expect(inserted[0].replies.map((comment) => comment.id)).toEqual(["child", "child-2"]);
+
+    const removed = removeCommentTree(inserted, "child");
+    expect(removed[0].replies.map((comment) => comment.id)).toEqual(["child-2"]);
+  });
+
   it("normalizes display names and sort options", () => {
     expect(normalizeDisplayName("  Alice ")).toBe("alice");
     expect(toCommentSortOption("recommended")).toBe("recommended");
@@ -67,6 +102,7 @@ describe("shared article helpers", () => {
     const result = formatCommentDate("2026-03-30T08:00:00.000Z", "en");
 
     expect(result).not.toBeNull();
+    expect(result?.label).toBeTruthy();
     expect(result?.dateTime).toBe("2026-03-30T08:00:00.000Z");
   });
 });

--- a/apps/web/src/components/articles/shared-article-helpers.test.ts
+++ b/apps/web/src/components/articles/shared-article-helpers.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatCommentDate,
+  normalizeDisplayName,
+  sortCommentThread,
+  toCommentSortOption,
+  withThreadDefaults,
+} from "@/components/articles/shared-article-helpers";
+import type { SharedArticleComment } from "@/lib/api/articles";
+
+function makeComment(partial: Partial<SharedArticleComment>): SharedArticleComment {
+  return {
+    id: partial.id ?? "comment-1",
+    content: partial.content ?? "hello",
+    created_at: partial.created_at ?? "2026-03-30T08:00:00.000Z",
+    updated_at: partial.updated_at ?? null,
+    user_id: partial.user_id ?? null,
+    author_name: partial.author_name ?? "tester",
+    author_image: partial.author_image ?? null,
+    parent_comment_id: partial.parent_comment_id ?? null,
+    empathy_count: partial.empathy_count ?? 0,
+    viewer_has_empathy: partial.viewer_has_empathy ?? false,
+    replies: partial.replies ?? [],
+  };
+}
+
+describe("shared article helpers", () => {
+  it("defaults nullable thread fields", () => {
+    const comments = withThreadDefaults([
+      makeComment({
+        author_image: undefined,
+        parent_comment_id: undefined,
+        empathy_count: undefined,
+        viewer_has_empathy: undefined,
+        replies: [makeComment({ id: "child-1" })],
+      }),
+    ]);
+
+    expect(comments[0].author_image).toBeNull();
+    expect(comments[0].parent_comment_id).toBeNull();
+    expect(comments[0].empathy_count).toBe(0);
+    expect(comments[0].viewer_has_empathy).toBe(false);
+    expect(comments[0].replies[0].id).toBe("child-1");
+  });
+
+  it("sorts recommended threads by empathy then recency", () => {
+    const comments = sortCommentThread(
+      [
+        makeComment({ id: "older", created_at: "2026-03-29T08:00:00.000Z", empathy_count: 1 }),
+        makeComment({ id: "newer", created_at: "2026-03-30T08:00:00.000Z", empathy_count: 1 }),
+        makeComment({ id: "top", created_at: "2026-03-28T08:00:00.000Z", empathy_count: 5 }),
+      ],
+      "recommended"
+    );
+
+    expect(comments.map((comment) => comment.id)).toEqual(["top", "newer", "older"]);
+  });
+
+  it("normalizes display names and sort options", () => {
+    expect(normalizeDisplayName("  Alice ")).toBe("alice");
+    expect(toCommentSortOption("recommended")).toBe("recommended");
+    expect(toCommentSortOption("anything-else")).toBe("latest");
+  });
+
+  it("formats valid comment dates", () => {
+    const result = formatCommentDate("2026-03-30T08:00:00.000Z", "en");
+
+    expect(result).not.toBeNull();
+    expect(result?.dateTime).toBe("2026-03-30T08:00:00.000Z");
+  });
+});

--- a/apps/web/src/components/articles/shared-article-helpers.ts
+++ b/apps/web/src/components/articles/shared-article-helpers.ts
@@ -1,0 +1,189 @@
+import type { SharedArticleComment } from "@/lib/api/articles";
+
+export interface ViewerProfile {
+  id: string | null;
+  name: string | null;
+  image: string | null;
+}
+
+export type CommentSortOption = "latest" | "recommended";
+
+export function readMetadataValue(metadata: unknown, key: string): string | null {
+  if (typeof metadata !== "object" || metadata === null) {
+    return null;
+  }
+
+  const value = (metadata as Record<string, unknown>)[key];
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function extractViewerProfile(user: unknown): ViewerProfile | null {
+  if (typeof user !== "object" || user === null) {
+    return null;
+  }
+
+  const userRecord = user as Record<string, unknown>;
+  const id =
+    typeof userRecord.id === "string" && userRecord.id.trim().length > 0 ? userRecord.id : null;
+  const email =
+    typeof userRecord.email === "string" && userRecord.email.trim().length > 0
+      ? userRecord.email
+      : null;
+  const metadata = userRecord.user_metadata;
+
+  const name =
+    readMetadataValue(metadata, "full_name") ?? readMetadataValue(metadata, "name") ?? email;
+  const image = readMetadataValue(metadata, "avatar_url") ?? readMetadataValue(metadata, "picture");
+
+  return {
+    id,
+    name,
+    image,
+  };
+}
+
+export function formatPublishedDate(value: string, locale: string): string | null {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+}
+
+export function withThreadDefaults(comments: SharedArticleComment[]): SharedArticleComment[] {
+  return comments.map((comment) => ({
+    ...comment,
+    author_image: comment.author_image ?? null,
+    parent_comment_id: comment.parent_comment_id ?? null,
+    empathy_count: comment.empathy_count ?? 0,
+    viewer_has_empathy: comment.viewer_has_empathy ?? false,
+    replies: withThreadDefaults(comment.replies ?? []),
+  }));
+}
+
+export function updateCommentTree(
+  comments: SharedArticleComment[],
+  targetCommentId: string,
+  updater: (comment: SharedArticleComment) => SharedArticleComment
+): SharedArticleComment[] {
+  return comments.map((comment) => {
+    if (comment.id === targetCommentId) {
+      return updater(comment);
+    }
+
+    if (comment.replies.length === 0) {
+      return comment;
+    }
+
+    return {
+      ...comment,
+      replies: updateCommentTree(comment.replies, targetCommentId, updater),
+    };
+  });
+}
+
+export function insertCommentTree(
+  comments: SharedArticleComment[],
+  newComment: SharedArticleComment
+): SharedArticleComment[] {
+  if (!newComment.parent_comment_id) {
+    return [newComment, ...comments];
+  }
+
+  return updateCommentTree(comments, newComment.parent_comment_id, (comment) => ({
+    ...comment,
+    replies: [...comment.replies, newComment],
+  }));
+}
+
+export function removeCommentTree(
+  comments: SharedArticleComment[],
+  targetCommentId: string
+): SharedArticleComment[] {
+  return comments.flatMap((comment) => {
+    if (comment.id === targetCommentId) {
+      return [];
+    }
+
+    if (comment.replies.length === 0) {
+      return [comment];
+    }
+
+    return [
+      {
+        ...comment,
+        replies: removeCommentTree(comment.replies, targetCommentId),
+      },
+    ];
+  });
+}
+
+export function formatCommentDate(
+  value: string,
+  locale: string
+): { label: string; dateTime: string } | null {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  const now = new Date();
+  const yearOptions = now.getFullYear() === date.getFullYear() ? {} : { year: "numeric" as const };
+
+  return {
+    label: new Intl.DateTimeFormat(locale, {
+      month: "short",
+      day: "numeric",
+      ...yearOptions,
+    }).format(date),
+    dateTime: date.toISOString(),
+  };
+}
+
+export function normalizeDisplayName(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+export function toCommentSortOption(value: string): CommentSortOption {
+  return value === "recommended" ? "recommended" : "latest";
+}
+
+export function getCommentTimestamp(comment: SharedArticleComment): number {
+  const timestamp = Date.parse(comment.created_at);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+export function getCommentEmpathyCount(comment: SharedArticleComment): number {
+  return typeof comment.empathy_count === "number" ? comment.empathy_count : 0;
+}
+
+export function sortCommentThread(
+  comments: SharedArticleComment[],
+  sortOption: CommentSortOption
+): SharedArticleComment[] {
+  return [...comments]
+    .sort((left, right) => {
+      if (sortOption === "recommended") {
+        const empathyDiff = getCommentEmpathyCount(right) - getCommentEmpathyCount(left);
+        if (empathyDiff !== 0) {
+          return empathyDiff;
+        }
+      }
+
+      return getCommentTimestamp(right) - getCommentTimestamp(left);
+    })
+    .map((comment) => ({
+      ...comment,
+      replies: sortCommentThread(comment.replies, sortOption),
+    }));
+}

--- a/apps/web/src/components/articles/shared-article-view.tsx
+++ b/apps/web/src/components/articles/shared-article-view.tsx
@@ -45,6 +45,20 @@ import {
   useToggleSharedArticleEmpathy,
   useUpdateSharedArticleComment,
 } from "@/lib/api/articles";
+import {
+  type CommentSortOption,
+  type ViewerProfile,
+  extractViewerProfile,
+  formatCommentDate,
+  formatPublishedDate,
+  insertCommentTree,
+  normalizeDisplayName,
+  removeCommentTree,
+  sortCommentThread,
+  toCommentSortOption,
+  updateCommentTree,
+  withThreadDefaults,
+} from "@/components/articles/shared-article-helpers";
 import { apiClient } from "@/lib/api-client";
 import { getSupabase } from "@/lib/auth/auth-client";
 import { locales } from "@/lib/i18n/config";
@@ -106,241 +120,6 @@ function LocaleSwitcher() {
 
 function isUuidLike(value: string): boolean {
   return UUID_LIKE_RE.test(value);
-}
-
-interface ViewerProfile {
-  id: string | null;
-  name: string | null;
-  image: string | null;
-}
-
-type CommentSortOption = "latest" | "recommended";
-
-const CONTENT_TYPE_STYLES: Record<string, { labelKey: ContentTypeLabelKey; className: string }> = {
-  tech_blog: {
-    labelKey: "typeTechBlog",
-    className:
-      "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-400/40 dark:bg-blue-500/15 dark:text-blue-200",
-  },
-  academic_paper: {
-    labelKey: "typePaper",
-    className:
-      "border-purple-200 bg-purple-50 text-purple-700 dark:border-purple-400/40 dark:bg-purple-500/15 dark:text-purple-200",
-  },
-  general_news: {
-    labelKey: "typeNews",
-    className:
-      "border-gray-200 bg-gray-50 text-gray-700 dark:border-gray-400/40 dark:bg-gray-500/15 dark:text-gray-200",
-  },
-  github_repo: {
-    labelKey: "typeGitHub",
-    className:
-      "border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-400/40 dark:bg-slate-500/15 dark:text-slate-200",
-  },
-  official_docs: {
-    labelKey: "typeDocs",
-    className:
-      "border-teal-200 bg-teal-50 text-teal-700 dark:border-teal-400/40 dark:bg-teal-500/15 dark:text-teal-200",
-  },
-  video_podcast: {
-    labelKey: "typeVideo",
-    className:
-      "border-pink-200 bg-pink-50 text-pink-700 dark:border-pink-400/40 dark:bg-pink-500/15 dark:text-pink-200",
-  },
-  patch_note: {
-    labelKey: "typePatchNote",
-    className:
-      "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-400/40 dark:bg-amber-500/15 dark:text-amber-200",
-  },
-};
-
-type ContentTypeLabelKey =
-  | "typeTechBlog"
-  | "typePaper"
-  | "typeNews"
-  | "typeGitHub"
-  | "typeDocs"
-  | "typeVideo"
-  | "typePatchNote";
-
-function readMetadataValue(metadata: unknown, key: string): string | null {
-  if (typeof metadata !== "object" || metadata === null) {
-    return null;
-  }
-
-  const value = (metadata as Record<string, unknown>)[key];
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function extractViewerProfile(user: unknown): ViewerProfile | null {
-  if (typeof user !== "object" || user === null) {
-    return null;
-  }
-
-  const userRecord = user as Record<string, unknown>;
-  const id =
-    typeof userRecord.id === "string" && userRecord.id.trim().length > 0 ? userRecord.id : null;
-  const email =
-    typeof userRecord.email === "string" && userRecord.email.trim().length > 0
-      ? userRecord.email
-      : null;
-  const metadata = userRecord.user_metadata;
-
-  const name =
-    readMetadataValue(metadata, "full_name") ?? readMetadataValue(metadata, "name") ?? email;
-  const image = readMetadataValue(metadata, "avatar_url") ?? readMetadataValue(metadata, "picture");
-
-  return {
-    id,
-    name,
-    image,
-  };
-}
-
-function formatPublishedDate(value: string, locale: string): string | null {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-
-  return new Intl.DateTimeFormat(locale, {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(date);
-}
-
-function withThreadDefaults(comments: SharedArticleComment[]): SharedArticleComment[] {
-  return comments.map((comment) => ({
-    ...comment,
-    author_image: comment.author_image ?? null,
-    parent_comment_id: comment.parent_comment_id ?? null,
-    empathy_count: comment.empathy_count ?? 0,
-    viewer_has_empathy: comment.viewer_has_empathy ?? false,
-    replies: withThreadDefaults(comment.replies ?? []),
-  }));
-}
-
-function updateCommentTree(
-  comments: SharedArticleComment[],
-  targetCommentId: string,
-  updater: (comment: SharedArticleComment) => SharedArticleComment
-): SharedArticleComment[] {
-  return comments.map((comment) => {
-    if (comment.id === targetCommentId) {
-      return updater(comment);
-    }
-
-    if (comment.replies.length === 0) {
-      return comment;
-    }
-
-    return {
-      ...comment,
-      replies: updateCommentTree(comment.replies, targetCommentId, updater),
-    };
-  });
-}
-
-function insertCommentTree(
-  comments: SharedArticleComment[],
-  newComment: SharedArticleComment
-): SharedArticleComment[] {
-  if (!newComment.parent_comment_id) {
-    return [newComment, ...comments];
-  }
-
-  return updateCommentTree(comments, newComment.parent_comment_id, (comment) => ({
-    ...comment,
-    replies: [...comment.replies, newComment],
-  }));
-}
-
-function removeCommentTree(
-  comments: SharedArticleComment[],
-  targetCommentId: string
-): SharedArticleComment[] {
-  return comments.flatMap((comment) => {
-    if (comment.id === targetCommentId) {
-      return [];
-    }
-
-    if (comment.replies.length === 0) {
-      return [comment];
-    }
-
-    return [
-      {
-        ...comment,
-        replies: removeCommentTree(comment.replies, targetCommentId),
-      },
-    ];
-  });
-}
-
-function formatCommentDate(
-  value: string,
-  locale: string
-): { label: string; dateTime: string } | null {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-
-  const now = new Date();
-  const yearOptions = now.getFullYear() === date.getFullYear() ? {} : { year: "numeric" as const };
-
-  return {
-    label: new Intl.DateTimeFormat(locale, {
-      month: "short",
-      day: "numeric",
-      ...yearOptions,
-    }).format(date),
-    dateTime: date.toISOString(),
-  };
-}
-
-function normalizeDisplayName(value: string | null | undefined): string {
-  return (value ?? "").trim().toLowerCase();
-}
-
-function toCommentSortOption(value: string): CommentSortOption {
-  return value === "recommended" ? "recommended" : "latest";
-}
-
-function getCommentTimestamp(comment: SharedArticleComment): number {
-  const timestamp = Date.parse(comment.created_at);
-  return Number.isNaN(timestamp) ? 0 : timestamp;
-}
-
-function getCommentEmpathyCount(comment: SharedArticleComment): number {
-  return typeof comment.empathy_count === "number" ? comment.empathy_count : 0;
-}
-
-function sortCommentThread(
-  comments: SharedArticleComment[],
-  sortOption: CommentSortOption
-): SharedArticleComment[] {
-  return [...comments]
-    .sort((left, right) => {
-      if (sortOption === "recommended") {
-        const empathyDiff = getCommentEmpathyCount(right) - getCommentEmpathyCount(left);
-        if (empathyDiff !== 0) {
-          return empathyDiff;
-        }
-      }
-
-      return getCommentTimestamp(right) - getCommentTimestamp(left);
-    })
-    .map((comment) => ({
-      ...comment,
-      replies: sortCommentThread(comment.replies, sortOption),
-    }));
 }
 
 export function SharedArticleView({


### PR DESCRIPTION
## 요약
- `shared-article-view` 내부에 섞여 있던 comment/viewer/date 관련 헬퍼를 별도 파일로 분리했습니다.
- 재사용 가능한 로직을 `shared-article-helpers.ts`로 이동해 컴포넌트 복잡도를 낮췄습니다.
- 정렬/기본값 보정/이름 정규화/날짜 포맷팅에 대한 테스트를 추가했습니다.

## 변경 사항
- `apps/web/src/components/articles/shared-article-helpers.ts` 추가
- `apps/web/src/components/articles/shared-article-view.tsx`에서 helper import 사용으로 정리
- `apps/web/src/components/articles/shared-article-helpers.test.ts` 추가

## 기대 효과
- `shared-article-view`의 책임을 조금 더 가볍게 만들어 후속 분해를 쉽게 합니다.
- 댓글 스레드 처리 로직을 테스트 가능한 단위로 분리해 회귀 위험을 낮춥니다.

## 테스트
- `shared-article-helpers.test.ts` 추가
- 현재 환경에서는 프로젝트 로컬 TypeScript/Bun toolchain 부재로 web 전체 실행 검증은 하지 못했습니다.

## 후속 작업 후보
- `shared-article-view` 내부의 UI 섹션 단위 분리
- comment state updater/use hook 분리
