### PR TITLE
refactor(api): extract article analysis profiles and cover them with tests

### DIFF
--- a/apps/api/src/articles/analysis_profiles.py
+++ b/apps/api/src/articles/analysis_profiles.py
@@ -1,0 +1,55 @@
+from src.lib.content_classifier import ContentType
+from src.lib.config import settings
+
+SLOW_ANALYSIS_CONTENT_TYPES = frozenset(
+    {
+        ContentType.OFFICIAL_DOCS,
+        ContentType.VIDEO_PODCAST,
+    }
+)
+
+# Academic papers get generous limits since they contain dense, important content.
+LARGE_CONTENT_TYPES = frozenset(
+    {
+        ContentType.ACADEMIC_PAPER,
+    }
+)
+
+
+def get_article_analysis_timeout_seconds(
+    content_type: ContentType = ContentType.GENERAL_NEWS,
+    *,
+    retry: bool = False,
+) -> int:
+    configured_timeout = int(getattr(settings, "ARTICLE_ANALYSIS_TIMEOUT_SECONDS", 45))
+    timeout = max(configured_timeout, 1)
+
+    # Academic papers get full timeout for large content processing.
+    if content_type in LARGE_CONTENT_TYPES:
+        return max(timeout - 15, 30) if retry else timeout
+
+    if content_type not in SLOW_ANALYSIS_CONTENT_TYPES:
+        return timeout
+
+    first_attempt_timeout = max(timeout - 15, 10)
+    if not retry:
+        return first_attempt_timeout
+
+    return max(first_attempt_timeout - 12, 6)
+
+
+def get_article_analysis_content_limit_chars(
+    content_type: ContentType = ContentType.GENERAL_NEWS,
+    *,
+    retry: bool = False,
+) -> int:
+    if content_type in LARGE_CONTENT_TYPES:
+        return 18000 if retry else 30000
+
+    if content_type not in SLOW_ANALYSIS_CONTENT_TYPES:
+        return 12000
+
+    if retry:
+        return 6500
+
+    return 9000

--- a/apps/api/src/articles/router.py
+++ b/apps/api/src/articles/router.py
@@ -13,6 +13,7 @@ from fastapi.responses import Response
 
 from src.articles import service
 from src.articles.analysis_profiles import (
+    SLOW_ANALYSIS_CONTENT_TYPES,
     get_article_analysis_content_limit_chars,
     get_article_analysis_timeout_seconds,
 )
@@ -226,10 +227,7 @@ async def _run_analysis(
                 timeout=initial_timeout_seconds,
             )
         except TimeoutError:
-            if analysis_content_type not in {
-                ContentType.OFFICIAL_DOCS,
-                ContentType.VIDEO_PODCAST,
-            }:
+            if analysis_content_type not in SLOW_ANALYSIS_CONTENT_TYPES:
                 raise
 
             retry_timeout_seconds = get_article_analysis_timeout_seconds(

--- a/apps/api/src/articles/router.py
+++ b/apps/api/src/articles/router.py
@@ -12,6 +12,10 @@ from fastapi import APIRouter, HTTPException, Query, status
 from fastapi.responses import Response
 
 from src.articles import service
+from src.articles.analysis_profiles import (
+    get_article_analysis_content_limit_chars,
+    get_article_analysis_timeout_seconds,
+)
 from src.articles.schemas import (
     ArticleAnalyzeURL,
     ArticleCreate,
@@ -73,60 +77,6 @@ def _parse_user_uuid_or_raise(user_id: str) -> uuid.UUID:
 VIDEO_TRANSCRIPT_MIN_CONTENT_CHARS = int(
     getattr(settings, "VIDEO_TRANSCRIPT_MIN_CONTENT_CHARS", 100)
 )
-
-SLOW_ANALYSIS_CONTENT_TYPES = frozenset(
-    {
-        ContentType.OFFICIAL_DOCS,
-        ContentType.VIDEO_PODCAST,
-    }
-)
-
-# Academic papers get generous limits since they contain dense, important content.
-LARGE_CONTENT_TYPES = frozenset(
-    {
-        ContentType.ACADEMIC_PAPER,
-    }
-)
-
-
-def get_article_analysis_timeout_seconds(
-    content_type: ContentType = ContentType.GENERAL_NEWS,
-    *,
-    retry: bool = False,
-) -> int:
-    configured_timeout = int(getattr(settings, "ARTICLE_ANALYSIS_TIMEOUT_SECONDS", 45))
-    timeout = max(configured_timeout, 1)
-
-    # Academic papers get full timeout for large content processing.
-    if content_type in LARGE_CONTENT_TYPES:
-        return max(timeout - 15, 30) if retry else timeout
-
-    if content_type not in SLOW_ANALYSIS_CONTENT_TYPES:
-        return timeout
-
-    first_attempt_timeout = max(timeout - 15, 10)
-    if not retry:
-        return first_attempt_timeout
-
-    return max(first_attempt_timeout - 12, 6)
-
-
-def get_article_analysis_content_limit_chars(
-    content_type: ContentType = ContentType.GENERAL_NEWS,
-    *,
-    retry: bool = False,
-) -> int:
-    if content_type in LARGE_CONTENT_TYPES:
-        return 18000 if retry else 30000
-
-    if content_type not in SLOW_ANALYSIS_CONTENT_TYPES:
-        return 12000
-
-    if retry:
-        return 6500
-
-    return 9000
-
 
 def resolve_content_type_for_retry(article: object) -> ContentType:
     summary = getattr(article, "summary", None)
@@ -276,7 +226,10 @@ async def _run_analysis(
                 timeout=initial_timeout_seconds,
             )
         except TimeoutError:
-            if analysis_content_type not in SLOW_ANALYSIS_CONTENT_TYPES:
+            if analysis_content_type not in {
+                ContentType.OFFICIAL_DOCS,
+                ContentType.VIDEO_PODCAST,
+            }:
                 raise
 
             retry_timeout_seconds = get_article_analysis_timeout_seconds(

--- a/apps/api/tests/test_analysis_profiles.py
+++ b/apps/api/tests/test_analysis_profiles.py
@@ -81,3 +81,58 @@ def test_content_limits_follow_profiles() -> None:
         )
         == 6500
     )
+
+
+def test_official_docs_timeout_uses_slow_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        analysis_profiles,
+        "settings",
+        SimpleNamespace(ARTICLE_ANALYSIS_TIMEOUT_SECONDS=45),
+    )
+
+    assert (
+        analysis_profiles.get_article_analysis_timeout_seconds(
+            ContentType.OFFICIAL_DOCS
+        )
+        == 30
+    )
+
+
+
+def test_academic_paper_profiles_use_large_content_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        analysis_profiles,
+        "settings",
+        SimpleNamespace(ARTICLE_ANALYSIS_TIMEOUT_SECONDS=45),
+    )
+
+    assert (
+        analysis_profiles.get_article_analysis_timeout_seconds(
+            ContentType.ACADEMIC_PAPER
+        )
+        == 45
+    )
+    assert (
+        analysis_profiles.get_article_analysis_timeout_seconds(
+            ContentType.ACADEMIC_PAPER,
+            retry=True,
+        )
+        == 30
+    )
+    assert (
+        analysis_profiles.get_article_analysis_content_limit_chars(
+            ContentType.ACADEMIC_PAPER
+        )
+        == 30000
+    )
+    assert (
+        analysis_profiles.get_article_analysis_content_limit_chars(
+            ContentType.ACADEMIC_PAPER,
+            retry=True,
+        )
+        == 18000
+    )

--- a/apps/api/tests/test_analysis_profiles.py
+++ b/apps/api/tests/test_analysis_profiles.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.articles import analysis_profiles
+from src.lib.content_classifier import ContentType
+
+
+def test_timeout_uses_configured_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        analysis_profiles,
+        "settings",
+        SimpleNamespace(ARTICLE_ANALYSIS_TIMEOUT_SECONDS=45),
+    )
+
+    assert analysis_profiles.get_article_analysis_timeout_seconds() == 45
+
+
+def test_timeout_clamps_minimum(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        analysis_profiles,
+        "settings",
+        SimpleNamespace(ARTICLE_ANALYSIS_TIMEOUT_SECONDS=0),
+    )
+
+    assert analysis_profiles.get_article_analysis_timeout_seconds() == 1
+
+
+def test_video_timeout_uses_shorter_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        analysis_profiles,
+        "settings",
+        SimpleNamespace(ARTICLE_ANALYSIS_TIMEOUT_SECONDS=45),
+    )
+
+    assert (
+        analysis_profiles.get_article_analysis_timeout_seconds(
+            ContentType.VIDEO_PODCAST
+        )
+        == 30
+    )
+
+
+def test_video_retry_uses_compact_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        analysis_profiles,
+        "settings",
+        SimpleNamespace(ARTICLE_ANALYSIS_TIMEOUT_SECONDS=45),
+    )
+
+    assert (
+        analysis_profiles.get_article_analysis_timeout_seconds(
+            ContentType.VIDEO_PODCAST,
+            retry=True,
+        )
+        == 18
+    )
+
+
+def test_content_limits_follow_profiles() -> None:
+    assert (
+        analysis_profiles.get_article_analysis_content_limit_chars(
+            ContentType.GENERAL_NEWS
+        )
+        == 12000
+    )
+    assert (
+        analysis_profiles.get_article_analysis_content_limit_chars(
+            ContentType.VIDEO_PODCAST
+        )
+        == 9000
+    )
+    assert (
+        analysis_profiles.get_article_analysis_content_limit_chars(
+            ContentType.VIDEO_PODCAST,
+            retry=True,
+        )
+        == 6500
+    )

--- a/apps/api/tests/test_article_analysis_async.py
+++ b/apps/api/tests/test_article_analysis_async.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from types import SimpleNamespace
 
 import pytest
 
@@ -76,83 +75,6 @@ async def test_run_analysis_async_does_not_mark_failed_if_usage_increment_fails(
     )
 
     assert updates == []
-
-
-def test_get_article_analysis_timeout_seconds_reads_settings(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        router,
-        "settings",
-        SimpleNamespace(ARTICLE_ANALYSIS_TIMEOUT_SECONDS=45),
-    )
-
-    assert router.get_article_analysis_timeout_seconds() == 45
-
-
-def test_get_article_analysis_timeout_seconds_clamps_minimum_value(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        router,
-        "settings",
-        SimpleNamespace(ARTICLE_ANALYSIS_TIMEOUT_SECONDS=0),
-    )
-
-    assert router.get_article_analysis_timeout_seconds() == 1
-
-
-def test_get_article_analysis_timeout_seconds_uses_shorter_profile_for_video(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        router,
-        "settings",
-        SimpleNamespace(ARTICLE_ANALYSIS_TIMEOUT_SECONDS=45),
-    )
-
-    assert (
-        router.get_article_analysis_timeout_seconds(router.ContentType.VIDEO_PODCAST)
-        == 30
-    )
-
-
-def test_get_article_analysis_timeout_seconds_uses_retry_profile_for_video(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        router,
-        "settings",
-        SimpleNamespace(ARTICLE_ANALYSIS_TIMEOUT_SECONDS=45),
-    )
-
-    assert (
-        router.get_article_analysis_timeout_seconds(
-            router.ContentType.VIDEO_PODCAST,
-            retry=True,
-        )
-        == 18
-    )
-
-
-def test_get_article_analysis_content_limit_chars_by_profile() -> None:
-    assert (
-        router.get_article_analysis_content_limit_chars(router.ContentType.GENERAL_NEWS)
-        == 12000
-    )
-    assert (
-        router.get_article_analysis_content_limit_chars(
-            router.ContentType.VIDEO_PODCAST
-        )
-        == 9000
-    )
-    assert (
-        router.get_article_analysis_content_limit_chars(
-            router.ContentType.VIDEO_PODCAST,
-            retry=True,
-        )
-        == 6500
-    )
 
 
 def test_is_nod_patch_note_url_accepts_changelog_detail_path() -> None:


### PR DESCRIPTION
## 요약
- article analysis timeout/content-limit 정책을 라우터에서 분리해 `analysis_profiles.py`로 이동했습니다.
- 정책 로직을 테스트 가능한 독립 모듈로 만들었습니다.
- 분석 프로필 관련 테스트를 추가해 timeout/content-limit 규칙을 고정했습니다.

## 변경 사항
- `apps/api/src/articles/analysis_profiles.py` 추가
- `apps/api/src/articles/router.py`에서 정책 함수 import 사용으로 정리
- `apps/api/tests/test_analysis_profiles.py` 추가

## 기대 효과
- 라우터가 정책 세부 구현을 덜 알게 되어 읽기 쉬워집니다.
- 향후 content type별 정책 조정 시 테스트 기반으로 수정할 수 있습니다.

## 테스트
- `test_analysis_profiles.py` 추가
- 현재 환경에서는 `uv`/`pytest`가 없어 직접 실행 검증은 하지 못했습니다.

## 후속 작업 후보
- `_run_analysis` 내부의 retry/persistence/dispatch 단계 추가 분리
- analysis policy를 더 선언적인 설정 구조로 정리
