### PR TITLE
refactor(worker): extract task registry and validate task payloads

### DIFF
--- a/apps/worker/src/routers/task_registry.py
+++ b/apps/worker/src/routers/task_registry.py
@@ -7,13 +7,21 @@ from src.routers.tasks import TaskPayload
 TaskHandler = Callable[[TaskPayload], Awaitable[None]]
 
 
+def require_article_id(payload: TaskPayload) -> str:
+    article_id = payload.data.get("article_id")
+    if not isinstance(article_id, str) or not article_id.strip():
+        msg = "Task payload must include a non-empty article_id"
+        raise ValueError(msg)
+    return article_id.strip()
+
+
 async def _handle_analysis(payload: TaskPayload) -> None:
-    article_id = str(payload.data.get("article_id", ""))
+    article_id = require_article_id(payload)
     await analyze_article(article_id)
 
 
 async def _handle_embedding(payload: TaskPayload) -> None:
-    article_id = str(payload.data.get("article_id", ""))
+    article_id = require_article_id(payload)
     await generate_embedding(article_id)
 
 

--- a/apps/worker/src/routers/task_registry.py
+++ b/apps/worker/src/routers/task_registry.py
@@ -1,0 +1,23 @@
+from collections.abc import Awaitable, Callable
+
+from src.jobs.analyze_article import analyze_article
+from src.jobs.generate_embedding import generate_embedding
+from src.routers.tasks import TaskPayload
+
+TaskHandler = Callable[[TaskPayload], Awaitable[None]]
+
+
+async def _handle_analysis(payload: TaskPayload) -> None:
+    article_id = str(payload.data.get("article_id", ""))
+    await analyze_article(article_id)
+
+
+async def _handle_embedding(payload: TaskPayload) -> None:
+    article_id = str(payload.data.get("article_id", ""))
+    await generate_embedding(article_id)
+
+
+TASK_HANDLERS: dict[str, TaskHandler] = {
+    "analysis": _handle_analysis,
+    "embedding": _handle_embedding,
+}

--- a/apps/worker/src/routers/task_registry.py
+++ b/apps/worker/src/routers/task_registry.py
@@ -1,8 +1,9 @@
+import uuid
 from collections.abc import Awaitable, Callable
 
 from src.jobs.analyze_article import analyze_article
 from src.jobs.generate_embedding import generate_embedding
-from src.routers.tasks import TaskPayload
+from src.routers.task_schemas import TaskPayload
 
 TaskHandler = Callable[[TaskPayload], Awaitable[None]]
 
@@ -12,7 +13,15 @@ def require_article_id(payload: TaskPayload) -> str:
     if not isinstance(article_id, str) or not article_id.strip():
         msg = "Task payload must include a non-empty article_id"
         raise ValueError(msg)
-    return article_id.strip()
+
+    normalized_article_id = article_id.strip()
+    try:
+        uuid.UUID(normalized_article_id)
+    except ValueError as exc:
+        msg = "Task payload article_id must be a valid UUID"
+        raise ValueError(msg) from exc
+
+    return normalized_article_id
 
 
 async def _handle_analysis(payload: TaskPayload) -> None:

--- a/apps/worker/src/routers/task_schemas.py
+++ b/apps/worker/src/routers/task_schemas.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class TaskPayload(BaseModel):
+    task_type: str
+    data: dict[str, object]

--- a/apps/worker/src/routers/tasks.py
+++ b/apps/worker/src/routers/tasks.py
@@ -31,4 +31,12 @@ async def execute_task(payload: TaskPayload) -> None:
         logger.warning("Unknown task type", task_type=payload.task_type)
         return
 
-    await handler(payload)
+    try:
+        await handler(payload)
+    except ValueError as exc:
+        logger.warning(
+            "Invalid task payload",
+            task_type=payload.task_type,
+            error=str(exc),
+            data=payload.data,
+        )

--- a/apps/worker/src/routers/tasks.py
+++ b/apps/worker/src/routers/tasks.py
@@ -24,16 +24,11 @@ async def process_task(
 async def execute_task(payload: TaskPayload) -> None:
     logger.info("Executing task", task_type=payload.task_type, data=payload.data)
 
-    match payload.task_type:
-        case "analysis":
-            from src.jobs.analyze_article import analyze_article
-            article_id = str(payload.data.get("article_id", ""))
-            await analyze_article(article_id)
+    from src.routers.task_registry import TASK_HANDLERS
 
-        case "embedding":
-            from src.jobs.generate_embedding import generate_embedding
-            article_id = str(payload.data.get("article_id", ""))
-            await generate_embedding(article_id)
+    handler = TASK_HANDLERS.get(payload.task_type)
+    if handler is None:
+        logger.warning("Unknown task type", task_type=payload.task_type)
+        return
 
-        case _:
-            logger.warning("Unknown task type", task_type=payload.task_type)
+    await handler(payload)

--- a/apps/worker/src/routers/tasks.py
+++ b/apps/worker/src/routers/tasks.py
@@ -1,15 +1,11 @@
 import structlog
 from fastapi import APIRouter, BackgroundTasks
-from pydantic import BaseModel
+
+from src.routers.task_schemas import TaskPayload
 
 logger = structlog.get_logger(__name__)
 
 router = APIRouter(tags=["Tasks"])
-
-
-class TaskPayload(BaseModel):
-    task_type: str
-    data: dict[str, object]
 
 
 @router.post("/process")
@@ -22,7 +18,7 @@ async def process_task(
 
 
 async def execute_task(payload: TaskPayload) -> None:
-    logger.info("Executing task", task_type=payload.task_type, data=payload.data)
+    logger.info("Executing task", task_type=payload.task_type)
 
     from src.routers.task_registry import TASK_HANDLERS
 
@@ -38,5 +34,5 @@ async def execute_task(payload: TaskPayload) -> None:
             "Invalid task payload",
             task_type=payload.task_type,
             error=str(exc),
-            data=payload.data,
         )
+        raise

--- a/apps/worker/tests/test_tasks.py
+++ b/apps/worker/tests/test_tasks.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.routers import tasks
+
+
+@pytest.mark.asyncio
+async def test_execute_task_dispatches_registered_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[dict[str, Any]] = []
+
+    async def _fake_handler(payload: tasks.TaskPayload) -> None:
+        called.append(payload.data)
+
+    monkeypatch.setattr(
+        "src.routers.task_registry.TASK_HANDLERS",
+        {"analysis": _fake_handler},
+    )
+
+    await tasks.execute_task(
+        tasks.TaskPayload(task_type="analysis", data={"article_id": "123"})
+    )
+
+    assert called == [{"article_id": "123"}]
+
+
+@pytest.mark.asyncio
+async def test_execute_task_ignores_unknown_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warnings: list[str] = []
+
+    def _fake_warning(message: str, **_: object) -> None:
+        warnings.append(message)
+
+    monkeypatch.setattr(tasks.logger, "warning", _fake_warning)
+    monkeypatch.setattr("src.routers.task_registry.TASK_HANDLERS", {})
+
+    await tasks.execute_task(tasks.TaskPayload(task_type="unknown", data={}))
+
+    assert warnings == ["Unknown task type"]

--- a/apps/worker/tests/test_tasks.py
+++ b/apps/worker/tests/test_tasks.py
@@ -43,3 +43,26 @@ async def test_execute_task_ignores_unknown_task(
     await tasks.execute_task(tasks.TaskPayload(task_type="unknown", data={}))
 
     assert warnings == ["Unknown task type"]
+
+
+@pytest.mark.asyncio
+async def test_execute_task_warns_on_invalid_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warnings: list[str] = []
+
+    async def _fake_handler(payload: tasks.TaskPayload) -> None:
+        raise ValueError(f"bad payload: {payload.data!r}")
+
+    def _fake_warning(message: str, **_: object) -> None:
+        warnings.append(message)
+
+    monkeypatch.setattr(tasks.logger, "warning", _fake_warning)
+    monkeypatch.setattr(
+        "src.routers.task_registry.TASK_HANDLERS",
+        {"analysis": _fake_handler},
+    )
+
+    await tasks.execute_task(tasks.TaskPayload(task_type="analysis", data={}))
+
+    assert warnings == ["Invalid task payload"]

--- a/apps/worker/tests/test_tasks.py
+++ b/apps/worker/tests/test_tasks.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 import pytest
 
 from src.routers import tasks
+from src.routers.task_schemas import TaskPayload
 
 
 @pytest.mark.asyncio
@@ -21,11 +23,13 @@ async def test_execute_task_dispatches_registered_handler(
         {"analysis": _fake_handler},
     )
 
+    article_id = str(uuid.uuid4())
+
     await tasks.execute_task(
-        tasks.TaskPayload(task_type="analysis", data={"article_id": "123"})
+        TaskPayload(task_type="analysis", data={"article_id": article_id})
     )
 
-    assert called == [{"article_id": "123"}]
+    assert called == [{"article_id": article_id}]
 
 
 @pytest.mark.asyncio
@@ -40,29 +44,23 @@ async def test_execute_task_ignores_unknown_task(
     monkeypatch.setattr(tasks.logger, "warning", _fake_warning)
     monkeypatch.setattr("src.routers.task_registry.TASK_HANDLERS", {})
 
-    await tasks.execute_task(tasks.TaskPayload(task_type="unknown", data={}))
+    await tasks.execute_task(TaskPayload(task_type="unknown", data={}))
 
     assert warnings == ["Unknown task type"]
 
 
 @pytest.mark.asyncio
-async def test_execute_task_warns_on_invalid_payload(
+async def test_execute_task_raises_on_invalid_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     warnings: list[str] = []
-
-    async def _fake_handler(payload: tasks.TaskPayload) -> None:
-        raise ValueError(f"bad payload: {payload.data!r}")
 
     def _fake_warning(message: str, **_: object) -> None:
         warnings.append(message)
 
     monkeypatch.setattr(tasks.logger, "warning", _fake_warning)
-    monkeypatch.setattr(
-        "src.routers.task_registry.TASK_HANDLERS",
-        {"analysis": _fake_handler},
-    )
 
-    await tasks.execute_task(tasks.TaskPayload(task_type="analysis", data={}))
+    with pytest.raises(ValueError, match="valid UUID"):
+        await tasks.execute_task(TaskPayload(task_type="analysis", data={"article_id": "not-a-uuid"}))
 
     assert warnings == ["Invalid task payload"]


### PR DESCRIPTION
## 요약
- worker task dispatch를 registry 방식으로 분리했습니다.
- task payload에서 `article_id`를 검증하도록 보강했습니다.
- unknown task / invalid payload 시 경고 로그를 남기도록 정리했습니다.
- task dispatch 및 invalid payload 동작 테스트를 추가했습니다.

## 변경 사항
- `apps/worker/src/routers/task_registry.py` 추가
- `apps/worker/src/routers/tasks.py`에서 registry 기반 dispatch 사용
- `apps/worker/tests/test_tasks.py` 추가 및 보강

## 기대 효과
- task type이 늘어날 때 분기문이 비대해지는 문제를 줄입니다.
- 잘못된 payload가 job 내부까지 들어가는 것을 조금 더 앞단에서 막습니다.

## 테스트
- `test_tasks.py` 추가/보강
- 현재 환경에서는 `uv`/`pytest`가 없어 직접 실행 검증은 하지 못했습니다.

## 후속 작업 후보
- payload schema를 task type별로 더 강하게 타입화
- retry/idempotency 정책 명시화
- background task가 아닌 큐 semantics 정리
