### PR TITLE
test(extension): cover auth, fetch, and refresh flows

### DIFF
--- a/apps/extension/src/lib/api.test.ts
+++ b/apps/extension/src/lib/api.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getToken: vi.fn(),
+  sendMessage: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock("./auth", () => ({
+  getToken: mocks.getToken,
+}));
+
+import { getUsageInfo } from "./api";
+
+vi.stubGlobal("navigator", { onLine: true, userAgent: "Vitest" });
+vi.stubGlobal("fetch", mocks.fetch);
+vi.stubGlobal("chrome", {
+  runtime: {
+    sendMessage: mocks.sendMessage,
+  },
+});
+
+describe("api request auth refresh", () => {
+  beforeEach(() => {
+    mocks.fetch.mockReset();
+    mocks.sendMessage.mockReset();
+    mocks.getToken.mockReset();
+  });
+
+  it("retries once after successful token refresh", async () => {
+    mocks.getToken
+      .mockResolvedValueOnce("expired-token")
+      .mockResolvedValueOnce("fresh-token");
+
+    mocks.fetch
+      .mockResolvedValueOnce(new Response(JSON.stringify({ detail: "expired" }), { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            plan: "free",
+            status: "active",
+            summaries_used: 1,
+            summaries_limit: 10,
+            can_summarize: true,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      );
+
+    mocks.sendMessage.mockImplementation(
+      (_message: unknown, cb: (response: { success: boolean }) => void) => {
+        cb({ success: true });
+      }
+    );
+
+    const result = await getUsageInfo();
+
+    expect(result.plan).toBe("free");
+    expect(mocks.fetch).toHaveBeenCalledTimes(2);
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws auth expired when refresh fails", async () => {
+    mocks.getToken.mockResolvedValue("expired-token");
+    mocks.fetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: "expired" }), { status: 401 })
+    );
+    mocks.sendMessage.mockImplementation(
+      (_message: unknown, cb: (response: { success: boolean }) => void) => {
+        cb({ success: false });
+      }
+    );
+
+    await expect(getUsageInfo()).rejects.toMatchObject({ code: "AUTH_EXPIRED" });
+  });
+});

--- a/apps/extension/src/lib/api.ts
+++ b/apps/extension/src/lib/api.ts
@@ -1,6 +1,11 @@
 import { getToken } from "./auth";
 import { API_BASE } from "./constants";
 import { ExtensionError } from "./errors";
+import {
+  isLikelyFetchNetworkError,
+  parseErrorMessage,
+  toUnknownRequestError,
+} from "./fetch";
 import type { SaveArticleRequest, SaveArticleResponse } from "../types/api";
 
 /**
@@ -71,15 +76,7 @@ async function apiRequest<T>(
         // handle the decision to log out after max retries.
       }
 
-      let errorMessage: string | undefined;
-      try {
-        const payload = (await response.clone().json()) as { detail?: string };
-        if (typeof payload?.detail === "string" && payload.detail.trim().length > 0) {
-          errorMessage = payload.detail;
-        }
-      } catch {
-        errorMessage = undefined;
-      }
+      const errorMessage = await parseErrorMessage(response);
 
       throw ExtensionError.fromResponse(response, errorMessage);
     }
@@ -90,16 +87,11 @@ async function apiRequest<T>(
       throw error;
     }
 
-    // Network error
-    if (error instanceof TypeError && error.message.includes("fetch")) {
+    if (isLikelyFetchNetworkError(error)) {
       throw ExtensionError.networkError();
     }
 
-    throw new ExtensionError(
-      "UNKNOWN",
-      error instanceof Error ? error.message : "Request failed",
-      true
-    );
+    throw toUnknownRequestError(error);
   }
 }
 

--- a/apps/extension/src/lib/auth.test.ts
+++ b/apps/extension/src/lib/auth.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearToken,
+  getRefreshToken,
+  getToken,
+  getUserInfo,
+  isAuthenticated,
+  setToken,
+} from "./auth";
+import { STORAGE_KEYS } from "./constants";
+
+const storage = new Map<string, unknown>();
+
+function encodeBase64Url(value: string): string {
+  return Buffer.from(value, "utf8")
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function createJwt(payload: Record<string, unknown>): string {
+  return [
+    encodeBase64Url(JSON.stringify({ alg: "none", typ: "JWT" })),
+    encodeBase64Url(JSON.stringify(payload)),
+    "signature",
+  ].join(".");
+}
+
+vi.stubGlobal("chrome", {
+  storage: {
+    local: {
+      get: vi.fn(async (keys: string[]) => {
+        const result: Record<string, unknown> = {};
+        for (const key of keys) {
+          if (storage.has(key)) {
+            result[key] = storage.get(key);
+          }
+        }
+        return result;
+      }),
+      set: vi.fn(async (data: Record<string, unknown>) => {
+        for (const [key, value] of Object.entries(data)) {
+          storage.set(key, value);
+        }
+      }),
+      remove: vi.fn(async (keys: string[]) => {
+        for (const key of keys) {
+          storage.delete(key);
+        }
+      }),
+    },
+  },
+});
+
+describe("auth helpers", () => {
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  it("stores token, refresh token, and extracted user info", async () => {
+    const token = createJwt({
+      email: "hello@example.com",
+      user_metadata: {
+        full_name: "Hello",
+        avatar_url: "https://example.com/avatar.png",
+      },
+    });
+
+    await setToken(token, 60, "refresh-123");
+
+    expect(storage.get(STORAGE_KEYS.AUTH_TOKEN)).toBe(token);
+    expect(storage.get(STORAGE_KEYS.REFRESH_TOKEN)).toBe("refresh-123");
+    expect(storage.get(STORAGE_KEYS.USER_INFO)).toEqual({
+      email: "hello@example.com",
+      name: "Hello",
+      avatarUrl: "https://example.com/avatar.png",
+    });
+  });
+
+  it("returns null and clears only expired access token fields", async () => {
+    storage.set(STORAGE_KEYS.AUTH_TOKEN, "expired-token");
+    storage.set(STORAGE_KEYS.TOKEN_EXPIRES, Date.now() - 1000);
+    storage.set(STORAGE_KEYS.REFRESH_TOKEN, "refresh-still-there");
+
+    await expect(getToken()).resolves.toBeNull();
+    expect(storage.has(STORAGE_KEYS.AUTH_TOKEN)).toBe(false);
+    expect(storage.has(STORAGE_KEYS.TOKEN_EXPIRES)).toBe(false);
+    expect(storage.get(STORAGE_KEYS.REFRESH_TOKEN)).toBe("refresh-still-there");
+  });
+
+  it("re-extracts and returns user info from stored token", async () => {
+    const token = createJwt({
+      email: "person@example.com",
+      user_metadata: {
+        name: "Person",
+        picture: "https://example.com/p.png",
+      },
+    });
+    storage.set(STORAGE_KEYS.AUTH_TOKEN, token);
+
+    await expect(getUserInfo()).resolves.toEqual({
+      email: "person@example.com",
+      name: "Person",
+      avatarUrl: "https://example.com/p.png",
+    });
+  });
+
+  it("reports auth state and clears all auth keys", async () => {
+    storage.set(STORAGE_KEYS.AUTH_TOKEN, "active-token");
+    storage.set(STORAGE_KEYS.REFRESH_TOKEN, "refresh-token");
+
+    await expect(isAuthenticated()).resolves.toBe(true);
+    await expect(getRefreshToken()).resolves.toBe("refresh-token");
+
+    await clearToken();
+
+    await expect(isAuthenticated()).resolves.toBe(false);
+    expect(storage.has(STORAGE_KEYS.AUTH_TOKEN)).toBe(false);
+    expect(storage.has(STORAGE_KEYS.REFRESH_TOKEN)).toBe(false);
+    expect(storage.has(STORAGE_KEYS.USER_INFO)).toBe(false);
+  });
+});

--- a/apps/extension/src/lib/fetch.test.ts
+++ b/apps/extension/src/lib/fetch.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { ExtensionError } from "./errors";
+import {
+  isLikelyFetchNetworkError,
+  parseErrorMessage,
+  toUnknownRequestError,
+} from "./fetch";
+
+describe("fetch helpers", () => {
+  it("parses detail from JSON error responses", async () => {
+    const response = new Response(JSON.stringify({ detail: "boom" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    await expect(parseErrorMessage(response)).resolves.toBe("boom");
+  });
+
+  it("returns undefined for non-json responses", async () => {
+    const response = new Response("not-json", { status: 500 });
+
+    await expect(parseErrorMessage(response)).resolves.toBeUndefined();
+  });
+
+  it("detects fetch network errors", () => {
+    expect(isLikelyFetchNetworkError(new TypeError("Failed to fetch"))).toBe(true);
+    expect(isLikelyFetchNetworkError(new Error("other"))).toBe(false);
+  });
+
+  it("wraps unknown request errors consistently", () => {
+    const error = toUnknownRequestError(new Error("kaput"));
+
+    expect(error).toBeInstanceOf(ExtensionError);
+    expect(error.code).toBe("UNKNOWN");
+    expect(error.message).toBe("kaput");
+  });
+});

--- a/apps/extension/src/lib/fetch.ts
+++ b/apps/extension/src/lib/fetch.ts
@@ -1,0 +1,26 @@
+import { ExtensionError } from "./errors";
+
+export async function parseErrorMessage(response: Response): Promise<string | undefined> {
+  try {
+    const payload = (await response.clone().json()) as { detail?: string };
+    if (typeof payload?.detail === "string" && payload.detail.trim().length > 0) {
+      return payload.detail;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+export function isLikelyFetchNetworkError(error: unknown): boolean {
+  return error instanceof TypeError && error.message.includes("fetch");
+}
+
+export function toUnknownRequestError(error: unknown): ExtensionError {
+  return new ExtensionError(
+    "UNKNOWN",
+    error instanceof Error ? error.message : "Request failed",
+    true
+  );
+}


### PR DESCRIPTION
## 요약
- extension API client에서 fetch 관련 보조 로직을 분리했습니다.
- auth helper 테스트를 추가했습니다.
- 401 응답 이후 refresh 성공/실패 흐름 테스트를 추가했습니다.
- extension 쪽 세션/인증 edge case에 대한 신뢰도를 높였습니다.

## 변경 사항
- `apps/extension/src/lib/fetch.ts` 추가
- `apps/extension/src/lib/fetch.test.ts` 추가
- `apps/extension/src/lib/auth.test.ts` 추가
- `apps/extension/src/lib/api.test.ts` 추가

## 기대 효과
- fetch/network/error parsing 로직이 분리되어 읽기 쉬워집니다.
- extension auth/session 흐름이 테스트로 고정되어 회귀 위험을 줄입니다.

## 테스트
- `npm exec -- vitest run apps/extension/src/lib/fetch.test.ts apps/extension/src/lib/auth.test.ts apps/extension/src/lib/api.test.ts`
- 결과: 3 files passed / 10 tests passed

## 후속 작업 후보
- extractor 관련 테스트 추가
- service worker refresh/backoff 정책 테스트 추가
