### PR TITLE
fix: resolve CI lint regressions after merged PRs

### DIFF
--- a/apps/api/src/articles/analysis_profiles.py
+++ b/apps/api/src/articles/analysis_profiles.py
@@ -1,5 +1,5 @@
-from src.lib.content_classifier import ContentType
 from src.lib.config import settings
+from src.lib.content_classifier import ContentType
 
 SLOW_ANALYSIS_CONTENT_TYPES = frozenset(
     {

--- a/apps/web/src/components/articles/shared-article-view.tsx
+++ b/apps/web/src/components/articles/shared-article-view.tsx
@@ -16,6 +16,20 @@ import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
 import { type FocusEvent, type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { ArticleMarkdownNote } from "@/components/articles/article-markdown-note";
+import {
+  type CommentSortOption,
+  type ViewerProfile,
+  extractViewerProfile,
+  formatCommentDate,
+  formatPublishedDate,
+  insertCommentTree,
+  normalizeDisplayName,
+  removeCommentTree,
+  sortCommentThread,
+  toCommentSortOption,
+  updateCommentTree,
+  withThreadDefaults,
+} from "@/components/articles/shared-article-helpers";
 import { NodWordmark } from "@/components/brand/nod-wordmark";
 import { LandingFooter } from "@/components/landing/footer";
 import { ThemeToggle } from "@/components/theme/theme-toggle";
@@ -45,20 +59,6 @@ import {
   useToggleSharedArticleEmpathy,
   useUpdateSharedArticleComment,
 } from "@/lib/api/articles";
-import {
-  type CommentSortOption,
-  type ViewerProfile,
-  extractViewerProfile,
-  formatCommentDate,
-  formatPublishedDate,
-  insertCommentTree,
-  normalizeDisplayName,
-  removeCommentTree,
-  sortCommentThread,
-  toCommentSortOption,
-  updateCommentTree,
-  withThreadDefaults,
-} from "@/components/articles/shared-article-helpers";
 import { apiClient } from "@/lib/api-client";
 import { getSupabase } from "@/lib/auth/auth-client";
 import { locales } from "@/lib/i18n/config";

--- a/apps/worker/tests/test_tasks.py
+++ b/apps/worker/tests/test_tasks.py
@@ -61,6 +61,11 @@ async def test_execute_task_raises_on_invalid_payload(
     monkeypatch.setattr(tasks.logger, "warning", _fake_warning)
 
     with pytest.raises(ValueError, match="valid UUID"):
-        await tasks.execute_task(TaskPayload(task_type="analysis", data={"article_id": "not-a-uuid"}))
+        await tasks.execute_task(
+            TaskPayload(
+                task_type="analysis",
+                data={"article_id": "not-a-uuid"},
+            )
+        )
 
     assert warnings == ["Invalid task payload"]


### PR DESCRIPTION
## 요약
- 머지 직후 main에서 실패한 CI lint 이슈를 정리했습니다.
- web, api, worker 각각에서 스타일/포맷팅 문제를 수정했습니다.

## 변경 사항
- web: `shared-article-view.tsx` import 정렬 수정
- api: `analysis_profiles.py` import 정렬 수정
- worker: `test_tasks.py` line length 수정

## 원인
- 이전 PR들은 기능/구조 변경 자체는 문제 없었지만, main 배포 워크플로의 lint 규칙(Biome/Ruff) 기준에서 작은 포맷팅 이슈가 남아 있었습니다.

## 기대 효과
- Deploy Web / Deploy API / Deploy Worker 워크플로의 lint 단계 복구
