### PR TITLE
fix(web): align helper imports with biome order

### DIFF
--- a/apps/web/src/components/articles/shared-article-view.tsx
+++ b/apps/web/src/components/articles/shared-article-view.tsx
@@ -18,7 +18,6 @@ import { type FocusEvent, type FormEvent, useEffect, useMemo, useRef, useState }
 import { ArticleMarkdownNote } from "@/components/articles/article-markdown-note";
 import {
   type CommentSortOption,
-  type ViewerProfile,
   extractViewerProfile,
   formatCommentDate,
   formatPublishedDate,
@@ -28,6 +27,7 @@ import {
   sortCommentThread,
   toCommentSortOption,
   updateCommentTree,
+  type ViewerProfile,
   withThreadDefaults,
 } from "@/components/articles/shared-article-helpers";
 import { NodWordmark } from "@/components/brand/nod-wordmark";


### PR DESCRIPTION
$## 요약\n- `shared-article-view.tsx`의 helper import 순서를 Biome 기대 형식에 맞게 조정했습니다.\n\n## 원인\n- 이전 hotfix에서 import 그룹 자체는 정리했지만, type/value import의 내부 정렬이 Biome 기준과 완전히 일치하지 않았습니다.\n\n## 기대 효과\n- Deploy Web 워크플로의 lint 단계 복구\n