### PR TITLE
Keep shared article OG content inside safe visual bounds

### DIFF
--- a/apps/web/src/app/api/og/shared-article/route.impl.test.tsx
+++ b/apps/web/src/app/api/og/shared-article/route.impl.test.tsx
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type ElementNode = {
+  props?: {
+    children?: unknown;
+    style?: Record<string, unknown>;
+  };
+};
+
+type CapturedImage = {
+  element: ElementNode;
+  options: {
+    width: number;
+    height: number;
+  };
+};
+
+const capturedImages: CapturedImage[] = [];
+
+vi.mock("next/og", () => ({
+  ImageResponse: class MockImageResponse {
+    headers = new Headers();
+
+    constructor(element: unknown, options: unknown) {
+      capturedImages.push({
+        element: element as ElementNode,
+        options: options as CapturedImage["options"],
+      });
+    }
+  },
+}));
+
+import { GET } from "./route.impl";
+
+function isElementNode(value: unknown): value is ElementNode {
+  return typeof value === "object" && value !== null && "props" in value;
+}
+
+function getChildren(node: ElementNode | null | undefined): ElementNode[] {
+  const children = node?.props?.children;
+  if (!children) {
+    return [];
+  }
+
+  return (Array.isArray(children) ? children : [children]).filter(isElementNode);
+}
+
+describe("shared article OG image layout", () => {
+  beforeEach(() => {
+    capturedImages.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it("keeps padded content inside the frame and centers the main content stack", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          title:
+            "i dug through claude code's leaked source and anthropic's codebase is absolutely unhinged",
+          summary:
+            "클로드의 소스 코드 일부가 유출되어 개발자들이 터미널 내 타마고치, 헥스 인코딩된 문자열, 거대한 파일 등 Anthropic의 개발 관행에 대해 논의했습니다.",
+          url: "https://www.reddit.com/r/programming/comments/abc123/example_thread/",
+          content_type: "discussion",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+
+    await GET(new Request("http://localhost/api/og/shared-article?shareId=test-share-id"));
+
+    const image = capturedImages.at(-1);
+    expect(image?.options).toEqual({ width: 1200, height: 630 });
+
+    const root = image?.element;
+    expect(root.props.style.boxSizing).toBe("border-box");
+    expect(root.props.style.padding).toBe("48px 48px 44px");
+
+    const [badgeRow, contentStack] = getChildren(root);
+    const [badgePill] = getChildren(badgeRow);
+
+    expect(badgePill.props.style.alignItems).toBe("center");
+    expect(badgePill.props.style.lineHeight).toBe(1.1);
+    expect(contentStack.props.style.justifyContent).toBe("center");
+
+    const [, , footerRow] = getChildren(contentStack);
+    expect(footerRow.props.style.marginTop).toBe("30px");
+    expect(footerRow.props.style.paddingTop).toBe("18px");
+  });
+});

--- a/apps/web/src/app/api/og/shared-article/route.impl.tsx
+++ b/apps/web/src/app/api/og/shared-article/route.impl.tsx
@@ -59,6 +59,7 @@ function renderFallbackImage() {
       style={{
         width: "100%",
         height: "100%",
+        boxSizing: "border-box",
         display: "flex",
         flexDirection: "column",
         justifyContent: "center",
@@ -93,9 +94,10 @@ function renderSharedImage(shared: SharedArticle) {
       style={{
         width: "100%",
         height: "100%",
+        boxSizing: "border-box",
         display: "flex",
         flexDirection: "column",
-        padding: "40px 48px 36px",
+        padding: "48px 48px 44px",
         background: `linear-gradient(135deg, ${gradient.from} 0%, ${gradient.to} 100%)`,
         color: "#ffffff",
       }}
@@ -106,10 +108,12 @@ function renderSharedImage(shared: SharedArticle) {
           <div
             style={{
               display: "flex",
-              padding: "6px 18px",
+              alignItems: "center",
+              padding: "8px 18px",
               borderRadius: "9999px",
               background: "rgba(255,255,255,0.15)",
-              fontSize: 20,
+              fontSize: 19,
+              lineHeight: 1.1,
               fontWeight: 700,
               color: "rgba(255,255,255,0.75)",
             }}
@@ -119,77 +123,85 @@ function renderSharedImage(shared: SharedArticle) {
         </div>
       ) : null}
 
-      {/* Spacer */}
-      <div style={{ display: "flex", flex: 1 }} />
-
-      {/* Title */}
       <div
         style={{
           display: "flex",
-          fontSize: 52,
-          lineHeight: 1.15,
-          fontWeight: 900,
-          maxWidth: "1100px",
+          flex: 1,
+          flexDirection: "column",
+          justifyContent: "center",
         }}
       >
-        {headline}
-      </div>
-
-      {/* Summary */}
-      <div
-        style={{
-          display: "flex",
-          marginTop: "20px",
-          fontSize: 24,
-          lineHeight: 1.55,
-          fontWeight: 400,
-          maxWidth: "1080px",
-          color: "rgba(255, 255, 255, 0.55)",
-        }}
-      >
-        {description}
-      </div>
-
-      {/* Bottom bar */}
-      <div
-        style={{
-          display: "flex",
-          marginTop: "28px",
-          paddingTop: "16px",
-          borderTop: "1.5px solid rgba(255,255,255,0.1)",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          {/* biome-ignore lint/performance/noImgElement: OG image JSX (ImageResponse) doesn't support next/image */}
-          <img
-            src="https://nod-archive.com/brand/nod-icon.png"
-            alt="NOD"
-            width={32}
-            height={32}
-            style={{ borderRadius: 4, opacity: 0.8 }}
-          />
-          <div
-            style={{
-              display: "flex",
-              fontSize: 22,
-              fontWeight: 700,
-              color: "rgba(255,255,255,0.55)",
-            }}
-          >
-            NOD
-          </div>
-        </div>
+        {/* Title */}
         <div
           style={{
             display: "flex",
-            fontSize: 20,
-            color: "rgba(255,255,255,0.35)",
+            fontSize: 52,
+            lineHeight: 1.15,
+            fontWeight: 900,
+            maxWidth: "1100px",
           }}
         >
-          {articleHost ?? "nod-archive.com"}
+          {headline}
+        </div>
+
+        {/* Summary */}
+        <div
+          style={{
+            display: "flex",
+            marginTop: "20px",
+            fontSize: 24,
+            lineHeight: 1.55,
+            fontWeight: 400,
+            maxWidth: "1080px",
+            color: "rgba(255, 255, 255, 0.55)",
+          }}
+        >
+          {description}
+        </div>
+
+        {/* Bottom bar */}
+        <div
+          style={{
+            display: "flex",
+            marginTop: "30px",
+            paddingTop: "18px",
+            borderTop: "1.5px solid rgba(255,255,255,0.1)",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            {/* biome-ignore lint/performance/noImgElement: OG image JSX (ImageResponse) doesn't support next/image */}
+            <img
+              src="https://nod-archive.com/brand/nod-icon.png"
+              alt="NOD"
+              width={32}
+              height={32}
+              style={{ borderRadius: 4, opacity: 0.8 }}
+            />
+            <div
+              style={{
+                display: "flex",
+                fontSize: 22,
+                lineHeight: 1.1,
+                fontWeight: 700,
+                color: "rgba(255,255,255,0.55)",
+              }}
+            >
+              NOD
+            </div>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 20,
+              lineHeight: 1.1,
+              color: "rgba(255,255,255,0.35)",
+            }}
+          >
+            {articleHost ?? "nod-archive.com"}
+          </div>
         </div>
       </div>
     </div>,


### PR DESCRIPTION
## Summary
- keep shared article OG padding inside the 1200x630 frame with border-box sizing
- center the title/summary/footer stack so the card is no longer bottom-heavy
- add a focused route-level regression test for the shared OG renderer

## Verification
- bun run lint
- bun x vitest run src/app/api/og/shared-article/route.impl.test.tsx
- bun run typecheck
- bun run test
- rendered PNG preview checked manually

## Notes
- local preview still logs the remote nod-icon asset as unsupported, but the text layout and footer clipping issue are fixed